### PR TITLE
safeFetch may handle `require()` returning an object with `{ default }`

### DIFF
--- a/src/utils/safeFetch.ts
+++ b/src/utils/safeFetch.ts
@@ -3,7 +3,12 @@ let nodeFetch: (...args) => Promise<Response> = null;
 // @ts-ignore
 if (typeof EdgeRuntime !== 'string') {
   try {
-    nodeFetch = require('node-fetch');
+    const obj = require('node-fetch');
+    if (typeof obj === 'function') {
+      nodeFetch = obj;
+    } else if (typeof obj.default === 'function') {
+      nodeFetch = obj.default;
+    }
   } catch (err) {
     // Ignore
   }
@@ -13,8 +18,7 @@ if (typeof EdgeRuntime !== 'string') {
 export default function safeFetch(...args): Promise<Response> {
   if (nodeFetch) {
     return nodeFetch(...args);
-  } else {
-    // @ts-ignore
-    return fetch(...args);
   }
+  // @ts-ignore
+  return fetch(...args);
 }


### PR DESCRIPTION
When bundled on the server, it was possible to encounter an error:

```
TypeError: nodeFetch.apply is not a function
    at new Promise (<anonymous>)
 ⨯ unhandledRejection: TypeError: nodeFetch.apply is not a function
```

This is likely because node-fetch and safeFetch are bundled in the server in such a way that `safeFetch` calls `require('node-fetch').apply(...)`, require() is implemented such that it returns an object, and so apply is not a function.

In the case where `typeof require('node-fetch')` is not a function, this PR will check for a function under the `.default` property